### PR TITLE
Don't allow System.out.println

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -190,5 +190,12 @@
       <property name="tagSeverity" value="error" />
       <message key="javadoc.writeTag" value="{0} tag is not allowed" />
     </module>
+    
+    <!-- No calls to System.out.println - ignoring comments -->
+    <module name="Regexp">
+      <property name="format" value="System\.out\.println" />
+      <property name="illegalPattern" value="true" />
+      <property name="ignoreComments" value="true" />
+    </module>
   </module>
 </module>


### PR DESCRIPTION
I have seen too many accidental System.out.println inclusions in code.  We explicitly state that only SLF4J should be used in our style guide.  There will be some new checkstyle errors once/if this change is approved so would need to communicate out the change.  It is possible that this could be too agressive and we either need to explicitly exclude main method or add something similar to

```
//CHECKSTYLE:OFF
public void someMethod(String arg1) {
//CHECKSTYLE:ON
```

@jhaber @mjball
