### PR TITLE
Suppress MethodName check for test methods

### DIFF
--- a/src/main/resources/checkstyle/basepom-policy-suppressions.xml
+++ b/src/main/resources/checkstyle/basepom-policy-suppressions.xml
@@ -19,4 +19,5 @@
 
 <suppressions>
   <suppress files="[\\/]generated-sources[\\/]" checks=".*"/>
+  <suppress files="[\\/]test[\\/].*Test\.java" checks="MethodName"/>
 </suppressions>


### PR DESCRIPTION
This enables the use of test-method naming conventions that use underscore characters to delimit specific sections of the name.

For example, see Roy Osherove's proposed UnitTest naming standards: http://osherove.com/blog/2005/4/3/naming-standards-for-unit-tests.html