### PR TITLE
Allows underscores in test method names

### DIFF
--- a/src/main/resources/checkstyle/basepom-policy-suppressions.xml
+++ b/src/main/resources/checkstyle/basepom-policy-suppressions.xml
@@ -19,4 +19,6 @@
 
 <suppressions>
   <suppress files="[\\/]generated-sources[\\/]" checks=".*"/>
+  <suppress files="[\\/]main[\\/]java[\\/].*\.java" id="EnforceTestMethodNaming"/>
+  <suppress files="[\\/]test[\\/]java[\\/].*Test\.java" id="EnforceMethodNaming"/>
 </suppressions>

--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -257,9 +257,11 @@
       <property name="id" value="EnforceGenericInterfaceTypeParameterNaming" />
       <property name="format" value="^[A-Z][A-Z0-9_]*$"/>
     </module>
+    <!-- Suppressed for test methods -->
     <module name="MethodName">
       <property name="id" value="EnforceMethodNaming" />
     </module>
+    <!-- Suppressed for non-test methods -->
     <module name="MethodName">
       <property name="id" value="EnforceTestMethodNaming" />
       <property name="format" value="^[a-z][a-zA-Z0-9_]*$" />

--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -132,7 +132,7 @@
       <property name="id" value="EnforceWhitespaceAfterTokens" />
       <property name="tokens" value="COMMA, SEMI, TYPECAST" />
     </module>
-    
+
     <module name="Indentation">
       <property name="id" value="EnforceIndentation" />
       <property name="basicOffset" value="2"/>
@@ -259,6 +259,10 @@
     </module>
     <module name="MethodName">
       <property name="id" value="EnforceMethodNaming" />
+    </module>
+    <module name="MethodName">
+      <property name="id" value="EnforceTestMethodNaming" />
+      <property name="format" value="^[a-z][a-zA-Z0-9_]*$" />
     </module>
     <module name="MethodTypeParameterName">
       <property name="id" value="EnforceGenericMethodTypeParameterNaming" />


### PR DESCRIPTION
This enables the use of test-method naming conventions that use underscore characters to delimit specific sections of the name.

For example, see Roy Osherove's proposed UnitTest naming standards: http://osherove.com/blog/2005/4/3/naming-standards-for-unit-tests.html

To make this work, two suppressions are added.  Suppress the EnforceTestMethodNaming for all "main" java files and suppress the regular EnforceMethodNaming for all test Java files.

Tested this locally.  Verified that a test method like "A_Test_Method" does not pass validation, but a test method like "a_test_method" does.  Also verified that "a_Method" for normal methods do not pass validation.