### PR TITLE
Only suppress  the desired check

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -58,6 +58,7 @@
     <module name="SuppressWithNearbyCommentFilter">
       <property name="commentFormat" value="SUPPRESS CHECKSTYLE FOR NEXT (\d+) LINES (\w+)"/>
       <property name="influenceFormat" value="$1"/>
+      <property name="checkFormat" value="$2"/>
     </module>
 
     <!-- Checks for imports                              -->


### PR DESCRIPTION
Currently the check capture group (\w+) is ignored, and the default for checkFormat is `.*`

http://checkstyle.sourceforge.net/config_filters.html#SuppressWithNearbyCommentFilter