### PR TITLE
Don't allow use of edu.emory.mathcs.backport

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -297,5 +297,9 @@
       <property name="tagSeverity" value="error" />
       <message key="javadoc.writeTag" value="{0} tag is not allowed" />
     </module>
+
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="edu.emory.mathcs.backport"/>
+    </module>
   </module>
 </module>


### PR DESCRIPTION
This package contains backports of various java 8 utilities and shouldn't be allowed.

@jhaber @kmclarnon 