### PR TITLE
Ban javafx.util package

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -305,7 +305,7 @@
     </module>
 
     <module name="IllegalImport">
-      <property name="illegalPkgs" value="edu.emory.mathcs.backport"/>
+      <property name="illegalPkgs" value="edu.emory.mathcs.backport, javafx.util"/>
     </module>
   </module>
 </module>


### PR DESCRIPTION
People were pulling in `javafx.util.Pair` and `javafx.util.Duration` which was breaking things compiling on JDK 11. There are some other classes in this package, but I think we're safe to ban it outright.

@jhaber @kmclarnon 