### PR TITLE
Update to new location for dtd

### DIFF
--- a/src/main/resources/checkstyle/basepom-policy-suppressions.xml
+++ b/src/main/resources/checkstyle/basepom-policy-suppressions.xml
@@ -14,8 +14,8 @@
 -->
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.1//EN"
+    "https://checkstyle.org/dtds/suppressions_1_1.dtd">
 
 <suppressions>
   <suppress files="[\\/]generated-sources[\\/]" checks=".*"/>


### PR DESCRIPTION
I noticed that the dtd we link to 404's. Investigation revealed they were removed from puppycrawl in February: https://github.com/oburn/oburn.github.io/commit/9f9b02c78906f64a3e79670901d58502c16078f9.

Looks like they moved to: https://checkstyle.org/dtds/suppressions_1_1.dtd

Per the contents of that file, I also updated the DOCTYPE definition.