### PR TITLE
Update configuration dtds

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-basepom.xml
+++ b/src/main/resources/checkstyle/checkstyle-basepom.xml
@@ -13,8 +13,8 @@
 ~   limitations under the License.
 -->
 <!DOCTYPE module PUBLIC
-"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "-//Checkstyle//DTD Check Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
   <!-- http://checkstyle.sourceforge.net/config_filters.html -->

--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -13,8 +13,8 @@
 ~   limitations under the License.
 -->
 <!DOCTYPE module PUBLIC
-"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "-//Checkstyle//DTD Check Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
   <property name="charset" value="UTF-8"/>


### PR DESCRIPTION
As in https://github.com/HubSpot/basepom-policy/pull/13, this moves us to the `dtd`s published by https://github.com/checkstyle/checkstyle/tree/master/src/main/resources/com/puppycrawl/tools/checkstyle

---
The license check succeeds locally, but fails in the branch build. Is this something I could have conceivably broken?

```
[INFO] Checking licenses...
[WARNING] Missing header in: /usr/share/hubspot/build/workspace/basepom-policy/pom.xml
```


---
@jhaber @bbeaudreault