### PR TITLE
Add minimal config

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-hubspot-minimal.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot-minimal.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Check Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <property name="charset" value="UTF-8"/>
+  <property name="fileExtensions" value="java, properties, xml"/>
+
+  <module name="SuppressWarningsFilter" />
+
+  <module name="SuppressionFilter">
+    <property name="file"
+              default="/checkstyle/basepom-policy-suppressions.xml"
+              value="${basepom.checkstyle.suppression-file}"/>
+  </module>
+
+  <!-- TODO replace with error-prone? -->
+  <!-- printStackTrace is always wrong -->
+  <module name="RegexpSingleline">
+    <property name="id" value="DisallowPrintStackTrace" />
+    <property name="format" value="\.printStackTrace\("/>
+    <property name="message" value="Replace printStackTrace with a logger"/>
+  </module>
+
+  <module name="TreeWalker">
+    <property name="cacheFile" value="${checkstyle.cache.file}"/>
+
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="SUPPRESS CHECKSTYLE FOR NEXT (\d+) LINES (\w+)"/>
+      <property name="influenceFormat" value="$1"/>
+    </module>
+
+    <!-- these seems out of scope for prettier-java -->
+    <!-- Checks for imports                              -->
+    <!-- See http://checkstyle.sf.net/config_import.html -->
+    <module name="AvoidStarImport">
+      <property name="id" value="DisallowStarImports" />
+      <property name="allowStaticMemberImports" value="true" />
+    </module>
+    <module name="RedundantImport">
+      <property name="id" value="DisallowRedundantImports" />
+    </module>
+    <module name="UnusedImports">
+      <property name="id" value="DisallowUnusedImports" />
+    </module>
+
+    <!-- TODO not handled by prettier-java yet https://github.com/jhipster/prettier-java/issues/291 -->
+    <!-- Modifier Checks                                    -->
+    <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+    <module name="ModifierOrder">
+      <property name="id" value="EnforceModifierOrder" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- UnusedModifier in PMD is also only warning -->
+    <module name="RedundantModifier">
+      <property name="id" value="DisallowRedundantModifiers" />
+      <property name="severity" value="warning"/>
+    </module>
+
+    <!-- TODO not currently handled by prettier-java -->
+    <!-- Checks that long constants are defined with an uppercase L -->
+    <module name="UpperEll">
+      <property name="id" value="EnforceUppercaseEllForLongConstants" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- Checks that the outer type name and the file name match -->
+    <module name="OuterTypeFilename">
+      <property name="id" value="EnforceClassAndFilenameMatch" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- Checks that each top-level class has its own file -->
+    <module name="OneTopLevelClass">
+      <property name="id" value="EnforceOneTopLevelClass" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- Checks that these blocks have some text inside -->
+    <module name="EmptyBlock">
+      <property name="id" value="DisallowEmptyBlocks" />
+      <property name="option" value="TEXT"/>
+      <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- Checks that each variable is defined on its own line -->
+    <module name="MultipleVariableDeclarations">
+      <property name="id" value="DisallowMultipleVariableDeclarations" />
+    </module>
+
+    <!-- TODO not currently handled by prettier-java -->
+    <!-- Checks for Java style array declarations instead of C style -->
+    <module name="ArrayTypeStyle">
+      <property name="id" value="DisallowCStyleArrayDeclarations" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- Checks state switch conditions don't fall through unless documented -->
+    <module name="FallThrough">
+      <property name="id" value="DisallowSwitchFallThrough" />
+    </module>
+
+    <!-- TODO replace with error-prone? -->
+    <!-- Checks that finalizers are not declared -->
+    <module name="NoFinalizer">
+      <property name="id" value="DisallowFinalizer" />
+    </module>
+
+    <!-- TODO replace with error-prone? -->
+    <!-- Checks that catch blocks are not empty -->
+    <module name="EmptyCatchBlock">
+      <property name="id" value="DisallowEmptyCatchBlock" />
+      <property name="exceptionVariableName" value="expected|ignored"/>
+    </module>
+
+    <!-- TODO replace with error-prone? -->
+    <!-- Checks that hashCode is overridden when equals is -->
+    <module name="EqualsHashCode">
+      <property name="id" value="EnforceHashCodeOverridden" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- Check that every class has a package and that the package matches the directory structure -->
+    <module name="PackageDeclaration">
+      <property name="id" value="EnforcePackageDeclaration" />
+      <property name="matchDirectoryStructure" value="true" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- Checks that everything is named appropriately -->
+    <module name="PackageName">
+      <property name="id" value="EnforcePackageNaming" />
+    </module>
+    <module name="TypeName">
+      <property name="id" value="EnforceClassNaming" />
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="id" value="EnforceGenericClassTypeParameterNaming" />
+      <property name="format" value="^[A-Z][A-Z0-9_]*$"/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="id" value="EnforceGenericInterfaceTypeParameterNaming" />
+      <property name="format" value="^[A-Z][A-Z0-9_]*$"/>
+    </module>
+    <!-- Suppressed for test methods -->
+    <module name="MethodName">
+      <property name="id" value="EnforceMethodNaming" />
+    </module>
+    <!-- Suppressed for non-test methods -->
+    <module name="MethodName">
+      <property name="id" value="EnforceTestMethodNaming" />
+      <property name="format" value="^[a-z][a-zA-Z0-9_]*$" />
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="id" value="EnforceGenericMethodTypeParameterNaming" />
+      <property name="format" value="^[A-Z][A-Z0-9_]*$"/>
+    </module>
+    <module name="ConstantName">
+      <property name="id" value="EnforceStaticFinalFieldNaming" />
+    </module>
+    <module name="StaticVariableName">
+      <property name="id" value="EnforceStaticFieldNaming" />
+    </module>
+    <module name="MemberName">
+      <property name="id" value="EnforceFieldNaming" />
+    </module>
+    <module name="ParameterName">
+      <property name="id" value="EnforceMethodParameterNaming" />
+    </module>
+    <module name="LocalVariableName">
+      <property name="id" value="EnforceLocalVariableNaming" />
+    </module>
+    <module name="LocalFinalVariableName">
+      <property name="id" value="EnforceLocalFinalVariableNaming" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <!-- Checks that @author javadoc tag does not exist. -->
+    <module name="WriteTag">
+      <property name="id" value="DisallowAuthorTag" />
+      <property name="tag" value="@author" />
+      <property name="tagFormat" value="\S" />
+      <property name="severity" value="ignore" />
+      <property name="tagSeverity" value="error" />
+      <message key="javadoc.writeTag" value="{0} tag is not allowed" />
+    </module>
+
+    <!-- this seems out of scope for prettier-java -->
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="edu.emory.mathcs.backport, javafx.util"/>
+    </module>
+  </module>
+</module>

--- a/src/main/resources/checkstyle/checkstyle-hubspot-minimal.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot-minimal.xml
@@ -45,7 +45,7 @@
       <property name="influenceFormat" value="$1"/>
     </module>
 
-    <!-- these seems out of scope for prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <!-- Checks for imports                              -->
     <!-- See http://checkstyle.sf.net/config_import.html -->
     <module name="AvoidStarImport">
@@ -79,13 +79,13 @@
       <property name="id" value="EnforceUppercaseEllForLongConstants" />
     </module>
 
-    <!-- this seems out of scope for prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <!-- Checks that the outer type name and the file name match -->
     <module name="OuterTypeFilename">
       <property name="id" value="EnforceClassAndFilenameMatch" />
     </module>
 
-    <!-- this seems out of scope for prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <!-- Checks that each top-level class has its own file -->
     <module name="OneTopLevelClass">
       <property name="id" value="EnforceOneTopLevelClass" />
@@ -99,19 +99,19 @@
       <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
     </module>
 
-    <!-- this seems out of scope for prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <!-- Checks that each variable is defined on its own line -->
     <module name="MultipleVariableDeclarations">
       <property name="id" value="DisallowMultipleVariableDeclarations" />
     </module>
 
-    <!-- TODO not currently handled by prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <!-- Checks for Java style array declarations instead of C style -->
     <module name="ArrayTypeStyle">
       <property name="id" value="DisallowCStyleArrayDeclarations" />
     </module>
 
-    <!-- this seems out of scope for prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <!-- Checks state switch conditions don't fall through unless documented -->
     <module name="FallThrough">
       <property name="id" value="DisallowSwitchFallThrough" />
@@ -136,7 +136,7 @@
       <property name="id" value="EnforceHashCodeOverridden" />
     </module>
 
-    <!-- this seems out of scope for prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <!-- Check that every class has a package and that the package matches the directory structure -->
     <module name="PackageDeclaration">
       <property name="id" value="EnforcePackageDeclaration" />
@@ -191,7 +191,7 @@
       <property name="id" value="EnforceLocalFinalVariableNaming" />
     </module>
 
-    <!-- this seems out of scope for prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <!-- Checks that @author javadoc tag does not exist. -->
     <module name="WriteTag">
       <property name="id" value="DisallowAuthorTag" />
@@ -202,7 +202,7 @@
       <message key="javadoc.writeTag" value="{0} tag is not allowed" />
     </module>
 
-    <!-- this seems out of scope for prettier-java -->
+    <!-- TODO replace with error-prone? -->
     <module name="IllegalImport">
       <property name="illegalPkgs" value="edu.emory.mathcs.backport, javafx.util"/>
     </module>


### PR DESCRIPTION
Adds a minimal checkstyle configuration that can be used in conjunction with prettier-java. Most of the remaining rules could eventually be migrated to either prettier-java or error-prone

@stevegutz @kmclarnon