### PR TITLE
Remove TreeWalker.cacheFile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${dep.plugin.license.version}</version>
                     <configuration>
-                        <skip>false</skip>
+                        <skip>true</skip>
                         <skipExistingHeaders>false</skipExistingHeaders>
                         <failIfMissing>true</failIfMissing>
                         <header>${project.basedir}/src/main/resources/license/basepom-apache-license-header.txt</header>

--- a/src/main/resources/checkstyle/checkstyle-basepom.xml
+++ b/src/main/resources/checkstyle/checkstyle-basepom.xml
@@ -49,8 +49,6 @@
   <!-- =========================================================== -->
 
   <module name="TreeWalker">
-    <property name="cacheFile" value="${checkstyle.cache.file}"/>
-
     <!-- http://checkstyle.sourceforge.net/config_filters.html -->
     <module name="SuppressWithNearbyCommentFilter"/>
 

--- a/src/main/resources/checkstyle/checkstyle-hubspot-minimal.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot-minimal.xml
@@ -37,8 +37,6 @@
   </module>
 
   <module name="TreeWalker">
-    <property name="cacheFile" value="${checkstyle.cache.file}"/>
-
     <module name="SuppressWarningsHolder" />
     <module name="SuppressWithNearbyCommentFilter">
       <property name="commentFormat" value="SUPPRESS CHECKSTYLE FOR NEXT (\d+) LINES (\w+)"/>

--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -52,8 +52,6 @@
   </module>
 
   <module name="TreeWalker">
-    <property name="cacheFile" value="${checkstyle.cache.file}"/>
-
     <module name="SuppressWarningsHolder" />
     <module name="SuppressWithNearbyCommentFilter">
       <property name="commentFormat" value="SUPPRESS CHECKSTYLE FOR NEXT (\d+) LINES (\w+)"/>


### PR DESCRIPTION
This removes `Remove TreeWalker.cacheFile` so that we can upgrade past checkstyle 8.19. I'll update our code to use this branch and then merge this PR once the upgrade is good.

Any objections to disabling the license check?

@jhaber @kmclarnon @Xcelled 