### PR TITLE
[checkstyle] Improve package name regex

### DIFF
--- a/src/main/resources/checkstyle/checkstyle-hubspot-minimal.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot-minimal.xml
@@ -147,6 +147,7 @@
     <!-- Checks that everything is named appropriately -->
     <module name="PackageName">
       <property name="id" value="EnforcePackageNaming" />
+      <property name="format" value="^[a-z][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$"/>
     </module>
     <module name="TypeName">
       <property name="id" value="EnforceClassNaming" />

--- a/src/main/resources/checkstyle/checkstyle-hubspot.xml
+++ b/src/main/resources/checkstyle/checkstyle-hubspot.xml
@@ -250,6 +250,7 @@
     <!-- Checks that everything is named appropriately -->
     <module name="PackageName">
       <property name="id" value="EnforcePackageNaming" />
+      <property name="format" value="^[a-z][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$"/>
     </module>
     <module name="TypeName">
       <property name="id" value="EnforceClassNaming" />


### PR DESCRIPTION
The built-in checkstyle rule only allows `[a-z]` before the first `.` in a package name. This was breaking on `twitter4j`, `twitter4j.core`, etc. Since it seems like this was based on an assumption that this would always be a top-level domain, eg `com` or `net`.

The built-in regex is `^[a-z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)*$`.

@jhaber @kmclarnon @Xcelled @cimmyv 